### PR TITLE
Fix git unsafe when in docker container

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,9 @@ echo "-----------------------------------------------------------"
 echo "### Printing environment"
 env
 
+#temporary fix for unsafe bug in git
+git config --global --add safe.directory $GITHUB_WORKSPACE
+
 echo "### Printing $GITHUB_EVENT_PATH"
 jq . "$GITHUB_EVENT_PATH"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,9 @@ echo "### Printing environment"
 env
 
 #temporary fix for unsafe bug in git
-git config --global --add safe.directory $GITHUB_WORKSPACE
+# git config --global --add safe.directory $GITHUB_WORKSPACE
+_GITHUB_REPO="${GITHUB_REPOSITORY##*/}"
+export GITHUB_WORKSPACE="$HOME/work/$_GITHUB_REPO/$_GITHUB_REPO"
 
 echo "### Printing $GITHUB_EVENT_PATH"
 jq . "$GITHUB_EVENT_PATH"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,10 +9,9 @@ echo "-----------------------------------------------------------"
 echo "### Printing environment"
 env
 
-#temporary fix for unsafe bug in git
-# git config --global --add safe.directory $GITHUB_WORKSPACE
-_GITHUB_REPO="${GITHUB_REPOSITORY##*/}"
-export GITHUB_WORKSPACE="$HOME/work/$_GITHUB_REPO/$_GITHUB_REPO"
+# Fix for unsafe path issue https://github.blog/2022-04-12-git-security-vulnerability-announced/
+# in git when running inside docker container
+git config --global --add safe.directory /github/workspace
 
 echo "### Printing $GITHUB_EVENT_PATH"
 jq . "$GITHUB_EVENT_PATH"


### PR DESCRIPTION
Fix for:
`fatal: unsafe repository ('/github/workspace' is owned by someone else)`

This happens when action is run inside docker container.